### PR TITLE
🎁 Added :x command

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -18,6 +18,10 @@ wq = ->
   w()
   q()
 
+x = ->
+  w()
+  q()
+
 qall = ->
   q() for item in atom.workspace.getPaneItems()
 
@@ -71,6 +75,7 @@ module.exports =
   normalCommands: {
     w
     wq
+    x
     wall
     wqall
     q


### PR DESCRIPTION
In vim, `:x` is a shortcut for `:wq`. It would be convenient to have `:x` available to quickly save and quit a file.