### PR TITLE
Add support for moving to relative line numbers

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -37,6 +37,10 @@ moveToLineAndColumn = (vimState, {row, column}) ->
 moveToLineByPercent = (vimState, {percent}) ->
   vimState.setCount(percent)
   vimState.operationStack.run('MoveToLineByPercent')
+  
+moveToRelativeLine = (vimState, {offset}) ->
+  vimState.setCount(offset+1)
+  vimState.operationStack.run('MoveToRelativeLine')
 
 normalCommands = {
   w
@@ -60,6 +64,7 @@ numberCommands = {
   moveToLine
   moveToLineAndColumn
   moveToLineByPercent
+  moveToRelativeLine
 }
 
 module.exports = {normalCommands, toggleCommands, numberCommands}

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -70,7 +70,7 @@ class View extends SelectListView
       items = @getItemsForKind('toggleCommands')
       items = fuzzaldrin.filter(items, filterQuery, key: @getFilterKey())
 
-    else if /^\d/.test(query)
+    else if /^[+-\d]/.test(query)
       name = null
 
       if match = query.match(/^(\d+)+$/)
@@ -84,6 +84,10 @@ class View extends SelectListView
       else if match = query.match(/^(\d+):(\d+)$/)
         name = 'moveToLineAndColumn'
         options = {row: Number(match[1]), column: Number(match[2])}
+        
+      else if match = query.match(/^([+-]\d+)$/)
+        name = 'moveToRelativeLine'
+        options = {offset: Number(match[1])}
 
       if name?
         item = @getItem('numberCommands', name)

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -63,7 +63,6 @@ class View extends SelectListView
     @panel?.hide()
 
   getFallBackItemsFromQuery: (query) ->
-    console.log("get items")
     items = []
 
     if /^!/.test(query)

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -63,6 +63,7 @@ class View extends SelectListView
     @panel?.hide()
 
   getFallBackItemsFromQuery: (query) ->
+    console.log("get items")
     items = []
 
     if /^!/.test(query)
@@ -70,7 +71,7 @@ class View extends SelectListView
       items = @getItemsForKind('toggleCommands')
       items = fuzzaldrin.filter(items, filterQuery, key: @getFilterKey())
 
-    else if /^\d/.test(query)
+    else if /^[+-\d]/.test(query)
       name = null
 
       if match = query.match(/^(\d+)+$/)
@@ -84,6 +85,10 @@ class View extends SelectListView
       else if match = query.match(/^(\d+):(\d+)$/)
         name = 'moveToLineAndColumn'
         options = {row: Number(match[1]), column: Number(match[2])}
+        
+      else if match = query.match(/^([+-]\d+)$/)
+        name = 'moveToRelativeLine'
+        options = {offset: Number(match[1])}
 
       if name?
         item = @getItem('numberCommands', name)


### PR DESCRIPTION
I like having relative line numbers (https://atom.io/packages/relative-numbers) displayed in my editor, and being able to jump to lines by a relative value goes hand in hand for my workflow. This PR adds the ability to go to lines by a relative value from within ex-mode. 

`:+12` will move forward 12 lines, `:-2` back two lines. 
